### PR TITLE
Fix 'TypeError: can only concatenate list (not "dict_items") to list'

### DIFF
--- a/scrapy_frontera/converters.py
+++ b/scrapy_frontera/converters.py
@@ -28,7 +28,7 @@ class RequestConverter(BaseRequestConverter):
         if isinstance(scrapy_request.cookies, dict):
             cookies = scrapy_request.cookies
         else:
-            cookies = dict(sum([d.items() for d in scrapy_request.cookies], []))
+            cookies = dict(sum([list(d.items()) for d in scrapy_request.cookies], []))
         cb = scrapy_request.callback
         if callable(cb):
             cb = _find_method(self.spider, cb)


### PR DESCRIPTION
I am getting the following error:
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/scrapy/utils/defer.py", line 102, in iter_errback
    yield next(it)
  File "/usr/local/lib/python3.6/site-packages/sh_scrapy/middlewares.py", line 30, in process_spider_output
    for x in result:
  File "/app/python/lib/python3.6/site-packages/scrapy_frontera/scheduler.py", line 47, in process_spider_output
    self.frontier.page_crawled(response)
  File "/app/python/lib/python3.6/site-packages/scrapy_frontera/manager.py", line 34, in page_crawled
    frontier_response = self.response_converter.to_frontier(response)
  File "/app/python/lib/python3.6/site-packages/scrapy_frontera/converters.py", line 102, in to_frontier
    self._request_converter.to_frontier(scrapy_response.request))
  File "/app/python/lib/python3.6/site-packages/scrapy_frontera/converters.py", line 29, in to_frontier
    cookies = dict(sum([d.items() for d in scrapy_request.cookies], []))
TypeError: can only concatenate list (not "dict_items") to list
```

This PR will make the code compatible with Python 3.